### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/custom-numbered-blocks/_schema.yml
+++ b/_extensions/custom-numbered-blocks/_schema.yml
@@ -1,0 +1,28 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  custom-numbered-blocks:
+    type: object
+    description: Configuration for custom numbered block classes, groups, and appearances.
+    properties:
+      classes:
+        type: object
+        description: Named custom block classes and their per-class settings.
+      groups:
+        type: object
+        description: Group definitions for shared counters and default appearance.
+      appearances:
+        type: object
+        description: Reusable appearance presets for custom numbered blocks.
+
+attributes:
+  Div:
+    label:
+      type: string
+      description: Display label prefix for a specific numbered block instance.
+    appearance:
+      type: string
+      description: Appearance preset name used for this block instance.
+    listin:
+      type: string
+      description: List target name where this block should be included.

--- a/_extensions/custom-numbered-blocks/_snippets.json
+++ b/_extensions/custom-numbered-blocks/_snippets.json
@@ -1,0 +1,22 @@
+{
+  "Custom numbered blocks setup": {
+    "prefix": "setup",
+    "body": [
+      "custom-numbered-blocks:",
+      "  classes:",
+      "    ${1:example}:",
+      "      label: \"${2:Example}\""
+    ],
+    "description": "Define a basic numbered block class in document metadata."
+  },
+  "Custom numbered block": {
+    "prefix": "block",
+    "body": [
+      "::: {.${1:example} #${2:ex-basic}}",
+      "## ${3:Example title}",
+      "${4:Block content.}",
+      ":::"
+    ],
+    "description": "Insert a numbered custom block with class and identifier."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/custom-numbered-blocks/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/custom-numbered-blocks/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html

---

For Quarto Wizard integrations, schema options should be scoped under `extensions.<extension-name>` in `_schema.yml`.

This scoping helps suggestions, completions, and hovering trigger reliably, and avoids option conflicts with other extensions and Quarto CLI options.

Reference: https://github.com/quarto-dev/quarto-cli/issues/12894
